### PR TITLE
Handle KeyError for 'completion' and add timeout for HTTPX client

### DIFF
--- a/claude_to_chatgpt/adapter.py
+++ b/claude_to_chatgpt/adapter.py
@@ -68,7 +68,7 @@ class ClaudeAdapter:
         return claude_params
 
     def claude_to_chatgpt_response_stream(self, claude_response, prev_decoded_response):
-        completion_tokens = num_tokens_from_string(claude_response["completion"])
+        completion_tokens = num_tokens_from_string(claude_response.get("completion", ""))
         openai_response = {
             "id": f"chatcmpl-{str(time.time())}",
             "object": "chat.completion.chunk",
@@ -98,7 +98,7 @@ class ClaudeAdapter:
         return openai_response
 
     def claude_to_chatgpt_response(self, claude_response):
-        completion_tokens = num_tokens_from_string(claude_response["completion"])
+        completion_tokens = num_tokens_from_string(claude_response.get("completion", ""))
         openai_response = {
             "id": f"chatcmpl-{str(time.time())}",
             "object": "chat.completion",

--- a/claude_to_chatgpt/adapter.py
+++ b/claude_to_chatgpt/adapter.py
@@ -131,7 +131,7 @@ class ClaudeAdapter:
         claude_params = self.openai_to_claude_params(openai_params)
         api_key = self.get_api_key(headers)
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=120.0) as client:
             if not claude_params.get("stream", False):
                 response = await client.post(
                     f"{self.claude_base_url}/v1/complete",


### PR DESCRIPTION
In this PR, we've made two improvements:

1. Added error handling for scenarios where the key 'completion' is not present in the 'claude_response' dictionary. This exception was causing the program to crash when the application tried to access the 'completion' key in the 'claude_response' dictionary. 

Now, the 'get' method is used on the dictionary which allows the program to provide a default value of an empty string if the 'completion' key is not present. This prevents a KeyError from being raised and allows the program to continue execution. The affected methods are 'claude_to_chatgpt_response_stream' and 'claude_to_chatgpt_response'.

This is an important fix that improves the robustness of the code by handling potential exceptions arising from unexpected data structures.

2. Implemented a timeout for the HTTPX client to avoid ReadTimeout errors. This change ensures the client operations do not hang indefinitely when there are network issues, by providing a predefined time limit for the request to either succeed or raise a timeout exception.

In both functions claude_to_chatgpt_response_stream and claude_to_chatgpt_response, claude_response.get("completion", "") is used instead of claude_response["completion"] to prevent KeyError if completion is not in claude_response. If completion is not present, it will return an empty string as default, and this empty string is then passed to num_tokens_from_string. Please adjust the default value according to your requirements.

-----

It is related to https://github.com/jtsang4/claude-to-chatgpt/issues/6 https://github.com/jtsang4/claude-to-chatgpt/issues/7 and https://github.com/jtsang4/claude-to-chatgpt/issues/2 . I think I fixed it. At least fixed the error when long query was sent.